### PR TITLE
Add line detector script with unit tests

### DIFF
--- a/line_detector/README.md
+++ b/line_detector/README.md
@@ -1,0 +1,25 @@
+# Line Detector
+
+This project provides a simple script to detect lines from a camera feed using OpenCV.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Single frame and save output:
+
+```bash
+python line_detector.py --camera-id 0 --mode single --save out.png
+```
+
+Stream mode:
+
+```bash
+python line_detector.py --mode stream
+```
+
+Use `--help` to see all parameters.

--- a/line_detector/line_detector.py
+++ b/line_detector/line_detector.py
@@ -1,0 +1,114 @@
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Detect lines from camera feed")
+    parser.add_argument("--camera-id", type=str, default="0", help="Camera index or path")
+    parser.add_argument("--mode", type=str, default="stream", choices=["single", "stream"], help="Operation mode")
+    parser.add_argument("--save", type=Path, default=None, help="Path to save single frame result")
+    parser.add_argument("--canny-th1", type=int, default=50, help="Lower threshold for Canny")
+    parser.add_argument("--canny-th2", type=int, default=150, help="Upper threshold for Canny")
+    parser.add_argument("--hough-th", type=int, default=50, help="Accumulator threshold for HoughLinesP")
+    parser.add_argument("--min-line-len", type=int, default=50, help="Minimum line length for HoughLinesP")
+    parser.add_argument("--max-line-gap", type=int, default=10, help="Maximum line gap for HoughLinesP")
+    return parser.parse_args()
+
+
+def setup_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+
+def open_camera(camera_id):
+    try:
+        cam_id = int(camera_id)
+    except ValueError:
+        cam_id = camera_id
+    cap = cv2.VideoCapture(cam_id)
+    if not cap.isOpened():
+        raise RuntimeError(f"Cannot open camera {camera_id}")
+    return cap
+
+
+def process_frame(frame, args):
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    edges = cv2.Canny(gray, args.canny_th1, args.canny_th2)
+    lines = cv2.HoughLinesP(edges, 1, np.pi / 180, args.hough_th,
+                            minLineLength=args.min_line_len,
+                            maxLineGap=args.max_line_gap)
+    output = np.zeros_like(frame)
+    if lines is not None:
+        for x1, y1, x2, y2 in lines[:, 0]:
+            cv2.line(output, (x1, y1), (x2, y2), (255, 255, 255), 2)
+    else:
+        logging.info("No lines detected")
+    return output
+
+
+def run_single(cap, args):
+    ret, frame = cap.read()
+    if not ret:
+        raise RuntimeError("Failed to read frame")
+    output = process_frame(frame, args)
+    if args.save:
+        cv2.imwrite(str(args.save), output)
+        logging.info("Saved result to %s", args.save)
+    cv2.imshow("Lines", output)
+    cv2.waitKey(0)
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+def run_stream(cap, args):
+    fps_counter = cv2.getTickFrequency()
+    timings = []
+    while True:
+        start = cv2.getTickCount()
+        ret, frame = cap.read()
+        if not ret:
+            logging.error("Failed to read frame")
+            break
+        output = process_frame(frame, args)
+        cv2.imshow("Lines", output)
+        key = cv2.waitKey(1)
+        elapsed = (cv2.getTickCount() - start) / fps_counter
+        timings.append(elapsed)
+        if key == 27:
+            break
+    cap.release()
+    cv2.destroyAllWindows()
+    if timings:
+        avg_fps = len(timings) / sum(timings)
+        logging.info("Average FPS: %.2f", avg_fps)
+
+
+def main():
+    args = parse_args()
+    setup_logging()
+    logging.info("Opening camera %s", args.camera_id)
+    cap = open_camera(args.camera_id)
+    try:
+        if args.mode == "single":
+            run_single(cap, args)
+        else:
+            run_stream(cap, args)
+    finally:
+        if cap.isOpened():
+            cap.release()
+        cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        logging.error("%s", exc)
+        sys.exit(1)

--- a/line_detector/requirements.txt
+++ b/line_detector/requirements.txt
@@ -1,0 +1,2 @@
+opencv-python~=4.10
+numpy>=1.21

--- a/line_detector/tests/test_line_detector.py
+++ b/line_detector/tests/test_line_detector.py
@@ -1,0 +1,37 @@
+import os
+import tempfile
+from unittest import TestCase, mock
+
+import cv2
+import numpy as np
+
+from line_detector import line_detector
+
+
+class TestLineDetector(TestCase):
+    def test_camera_unavailable(self):
+        with self.assertRaises(RuntimeError):
+            line_detector.open_camera("invalid://0")
+
+    def test_detect_lines_in_image(self):
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        cv2.line(img, (10, 10), (90, 10), (255, 255, 255), 2)
+        cv2.line(img, (10, 20), (90, 20), (255, 255, 255), 2)
+        args = mock.Mock(canny_th1=50, canny_th2=150, hough_th=30,
+                         min_line_len=10, max_line_gap=5)
+        output = line_detector.process_frame(img, args)
+        self.assertGreater(np.sum(output > 0), 0)
+
+    def test_single_mode_save(self):
+        dummy_frame = np.zeros((10, 10, 3), dtype=np.uint8)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = os.path.join(tmpdir, "out.png")
+            cap = mock.Mock()
+            cap.read.return_value = (True, dummy_frame)
+            cap.isOpened.return_value = True
+            args = mock.Mock(save=save_path, canny_th1=50, canny_th2=150,
+                             hough_th=30, min_line_len=10, max_line_gap=5)
+            with mock.patch("cv2.imshow"), mock.patch("cv2.waitKey", return_value=27):
+                line_detector.run_single(cap, args)
+            self.assertTrue(os.path.exists(save_path))
+            self.assertGreater(os.path.getsize(save_path), 0)


### PR DESCRIPTION
## Summary
- implement `line_detector.py` with line detection from camera
- add requirements and usage docs
- provide unit tests for camera failure, line detection and saving

## Testing
- `pip install -r line_detector/requirements.txt`
- `python -m unittest discover -v line_detector/tests`

------
https://chatgpt.com/codex/tasks/task_e_684ab64b9338832094c9bf6dd6b49c71